### PR TITLE
Adding support for 'disk' target

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.lwansbrough.ReactCamera">
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-feature android:name="android.hardware.camera" />
-  <uses-feature android:name="android.hardware.camera.autofocus" />
+  <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 </manifest>

--- a/index.android.js
+++ b/index.android.js
@@ -1,10 +1,12 @@
 var React = require('react-native');
+var View = require('View');
 var { requireNativeComponent, PropTypes, NativeModules } = React;
 
 var ReactNativeCameraModule = NativeModules.ReactCameraModule;
 var ReactCameraView = requireNativeComponent('ReactCameraView', {
     name: 'ReactCameraView',
     propTypes: {
+        ...View.propTypes,
         scaleX: PropTypes.number,
         scaleY: PropTypes.number,
         translateX: PropTypes.number,

--- a/index.ios.js
+++ b/index.ios.js
@@ -1,4 +1,5 @@
 var React = require('react-native');
+var View = require('View');
 var { StyleSheet, requireNativeComponent, PropTypes, NativeModules, DeviceEventEmitter } = React;
 
 var CAMERA_REF = 'camera';
@@ -16,6 +17,7 @@ var constants = {
 
 var Camera = React.createClass({
   propTypes: {
+    ...View.propTypes,
     aspect: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number


### PR DESCRIPTION
In order to comply with ios lib 'file' was changed to 'disk' and 'disk' target was added.
In order to be available in more Android devices autofocus requirement was made optional in AndroidManifest file
RN 0.16 path by eiriksm added
