### PR TITLE
fix disk implementation (much faster)

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -98,9 +98,9 @@ var ReactCameraViewWrapper = React.createClass({
                 callback = options;
                 options = {};
             }
-            ReactNativeCameraModule.capture(Object.assign(defaultOptions, options || {}), function(encoded) {
-                if (typeof callback === 'function') callback(null, encoded);
-                resolve(encoded);
+            ReactNativeCameraModule.capture(Object.assign(defaultOptions, options || {}), function(err, data) {
+                if (typeof callback === 'function') callback(err, data);
+                err ? reject(err) : resolve(data);
             });
         });
     }


### PR DESCRIPTION
This PR avoids the bitmap conversion which is very slow in my tests (5+ seconds). When writing the data straight to disk I get ~500ms.

Also switches to error first callback and rejects the promise on error
